### PR TITLE
Adding link to COC file

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCS_ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/DOCS_ISSUE.yml
@@ -37,5 +37,5 @@ body:
       label: Code of Conduct
       description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/semaphoreci/semaphore/tree/main?tab=coc-ov-file). 
       options:
-        - label: I agree to follow this project's Code of Conduct
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/semaphoreci/semaphore?tab=coc-ov-file)
           required: true


### PR DESCRIPTION
## What
<!-- A summary of the changes made. -->
Updated the docs issue template to include the link to the code of conduct. 

## Why
<!-- The reason for the changes and any relevant background. -->
- It is easier for people that are opening/contributing to issue to navigate to code of conduct before agreeing.
- It was not clear to some contributors where code of conduct was located.

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [x] The branch is up-to-date with the main branch.
- [ ] ~Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).~
- [ ] ~Changes have been tested locally.~
