### PR TITLE
Add robots.txt to disable Search Engine indexing

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,6 +8,9 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
+  // disable this setting when the site goes to production to allow Google to index
+  // https://docusaurus.io/docs/next/api/docusaurus-config#noIndex
+  noIndex: true,
   title: 'Semaphore Docs',
   tagline: 'Intuitive Continuous Integration and Delivery',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
## What
Enable noIndex in the docusaurus config to prevent indexing search engines

## Why
We don't want any search indexes to access the in-progress pages. We'll re-enable indexing when the site is in production.

Addresses #88 

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [X] The branch is up-to-date with the main branch.
- [X] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [X] Changes have been tested locally.
