### PR TITLE
Fix default base url for deployment

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -37,7 +37,7 @@ const config = {
   url: 'https://docs.semaphoreci.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: process.env.BASE_URL ? process.env.BASE_URL : '/',
+  baseUrl: process.env.BASE_URL ? process.env.BASE_URL : '/sem-docs/main/',
 
   // GitHub org and project. Needed for Github Pages.
   organizationName: 'semaphoreci',


### PR DESCRIPTION
## What
<!-- A summary of the changes made. -->
Fixes the default `baseUrl` of docusaurus so docusaurus will work from the s3 bucket
## Why
<!-- The reason for the changes and any relevant background. -->
We deploy the build into a S3 bucket in `/sem-docs/{branch}` path. This will fix deployments from master by default.
## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [x] The branch is up-to-date with the main branch.
- [x] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [x] Changes have been tested locally.
