### PR TITLE
Formatting adjustments - self-hosted AWS page

### DIFF
--- a/docs/docs/using-semaphore/self-hosted-aws.md
+++ b/docs/docs/using-semaphore/self-hosted-aws.md
@@ -144,7 +144,8 @@ Follow these steps to deploy self-hosted agents in AWS.
     - `<your-organization>.semaphoreci.com` with your [organization URL](./organizations#general-settings), e.g. `my-org.semaphoreci.com`
     - `<license-configuration>` the license information from Apple (only for macOS)
 
-    <details>
+    <br>
+   <details>
     <summary>Linux</summary>
     <div>
 
@@ -208,7 +209,7 @@ Follow these steps to deploy self-hosted agents in AWS.
     </div>
     </details>
 
-6. Bootstrap the CDK application
+7. Bootstrap the CDK application
 
     Open the file `execution-policy.json` created in Step 4 and copy the ARN value. 
     Replace:
@@ -228,7 +229,7 @@ Follow these steps to deploy self-hosted agents in AWS.
 
     :::
 
-7. Deploy the stack
+8. Deploy the stack
 
     To deploy the stack, execute the following command
 


### PR DESCRIPTION
## What

A slight formatting adjustment. I added a break between text and expandable sections for OS type. 

## Why
This change is created during the review of: https://github.com/semaphoreci/semaphore/issues/82

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [x] The branch is up-to-date with the main branch.
- [x] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [ ] Changes have been tested locally.
