### PR TITLE
Try fixing algolia crawler issues

### DIFF
--- a/docs/default.conf
+++ b/docs/default.conf
@@ -12,7 +12,7 @@ server {
     }
 
     # this directive fixes Algolia Crawler issues
-    location /?$ {
+    location / {
       try_files $uri $uri/index.html $uri/ =404;
     }
 


### PR DESCRIPTION
## What
Update NGINX default.conf to fix Algolia Cralwer

## Why
Algolia Crawler stopped working after https://github.com/semaphoreci/semaphore/pull/277 was merged. This change attempts to fix the NGINX conf so the crawler resumes working. See https://github.com/orgs/semaphoreci/projects/2/views/1?pane=issue&itemId=74477535&issue=semaphoreci%7Csemaphore%7C157

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [x] The branch is up-to-date with the main branch.
- [x] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [x] Changes have been tested locally.
