### PR TITLE
Replace token param docs with correct reference

### DIFF
--- a/docs/docs/using-semaphore/self-hosted-install.md
+++ b/docs/docs/using-semaphore/self-hosted-install.md
@@ -183,7 +183,7 @@ To install the Semaphore custom controller, follow these steps:
     Replace:
 
     - `<my-org.semaphoreci.com>` with your [organization URL](./organizations#general-settings)
-    - `<token>` with the [registration token](#register-agent) you received earlier
+    - `<token>` with a valid [Semaphore API token](https://docs.semaphoreci.com/reference/api#authentication)
 
 4. Create a secret to register the agent type in the Kubernetes cluster. Create a new YAML resource file.
 


### PR DESCRIPTION
## What
-  in Step 3 the following bullet point is wrong
```md
- `<token>` with the [registration token](https://docs.semaphoreci.com/using-semaphore/self-hosted-install#register-agent) you received earlier
```
- It should be replaced with
```md
- `<token>` with a valid [Semaphore API token](https://docs.semaphoreci.com/reference/api#authentication)
```

## Why
A bug was reported, it can be verified in the following issue: https://github.com/semaphoreci/semaphore/issues/281
The helm controller link is already added in the docs, at https://github.com/semaphoreci/semaphore/blob/main/docs/docs/using-semaphore/self-hosted-install.md?plain=1#L220

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [x] The branch is up-to-date with the main branch.
- [x] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [x] Changes have been tested locally.
