### PR TITLE
Removed incorrect information about Java 21

### DIFF
--- a/docs/docs/reference/os-ubuntu.md
+++ b/docs/docs/reference/os-ubuntu.md
@@ -304,7 +304,7 @@ Additional libraries:
 <summary>Java and JVM languages</summary>
 <div>
 
-- Java: 11.0.24, 17.0.12 (default), 21.0.4
+- Java: 11.0.24, 17.0.12 (default)
 - Scala: 3.2.2
 - Leiningen: 2.11.2 (Clojure)
 - Sbt 1.10.1


### PR DESCRIPTION
## What
Removed Java 21 from the Ubuntu 22.04 reference, since it isn't available.

## Why
Please see: https://github.com/semaphoreci/semaphore/issues/288

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [X] The branch is up-to-date with the main branch.
- [X] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [X] Changes have been tested locally.
