### PR TITLE
Added a note about job epilogues

### DIFF
--- a/docs/docs/reference/env-vars.md
+++ b/docs/docs/reference/env-vars.md
@@ -113,6 +113,12 @@ Describes the ending state of the job. The possible states are:
 - `failed`: the job finished in failure
 - `stopped`: the job was terminated before completion
 
+:::note
+
+This variable is only available in the [job epilogue](../using-semaphore/jobs#epilogue).
+
+:::
+
 ### Job type {#job-type}
 
 - **Environment variable**: `SEMAPHORE_JOB_TYPE`


### PR DESCRIPTION
## What
I added a note to mention that the `SEMAPHORE_JOB_RESULT` variable is only available in the job epilogue.

## Why
There has been some confusion about this.

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [X] The branch is up-to-date with the main branch.
- [X] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [X] Changes have been tested locally.
