### PR TITLE
Added docker rate limit information to the FAQ

### DIFF
--- a/docs/docs/getting-started/faq.md
+++ b/docs/docs/getting-started/faq.md
@@ -407,6 +407,18 @@ Some commands like `bash -e` or `set -x otrace` may override this behavior and m
 
 :::
 
+### Help! Docker fails with "toomanyrequests"
+
+This is commonly due to a rate-limit of third-party providers such as Docker Hub. These services limit how many unauthenticated pulls you can do in an hour, often based on IP. The machine you are running your jobs on may have been provisioned for another user, resulting in that particular IP being rate-limited.
+
+You can bypass this issue by creating a free account on Docker Hub, and then [authenticating with Docker](../using-semaphore/optimization/docker#auth) within the job. This way, the pulls are limited by your account (ten times more), and not by the IP of the machine.
+
+:::tip
+
+If you cannot authenticate, you can use other third-party Docker registries such as the [ECR Public Gallery](https://gallery.ecr.aws/).
+
+:::
+
 
 ## Project
 

--- a/docs/docs/getting-started/faq.md
+++ b/docs/docs/getting-started/faq.md
@@ -411,7 +411,7 @@ Some commands like `bash -e` or `set -x otrace` may override this behavior and m
 
 This is commonly due to a rate-limit of third-party providers such as Docker Hub. These services limit how many unauthenticated pulls you can do in an hour, often based on IP. The machine you are running your jobs on may have been provisioned for another user, resulting in that particular IP being rate-limited.
 
-You can bypass this issue by creating a free account on Docker Hub, and then [authenticating with Docker](../using-semaphore/optimization/docker#auth) within the job. This way, the pulls are limited by your account (ten times more), and not by the IP of the machine.
+You can bypass this issue by creating a free account on Docker Hub, and then [authenticating with Docker](../using-semaphore/optimization/docker#auth) within the job. This way, the [pulls are limited by your account (100 per hour)](https://docs.docker.com/docker-hub/usage/), and not by the IP of the machine.
 
 :::tip
 


### PR DESCRIPTION
## What
I added some information about Docker rate limits our customers may run into.

## Why
Docker Hub limits the pulls to 10 an hour from a certain IP address for unauthenticated pulls. This means that it is flaky behavior, it rolls the dice if the machine the customer's jobs are running on has been rate-limit yet or not. Logging in resolves this issue.

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [X] The branch is up-to-date with the main branch.
- [X] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [X] Changes have been tested locally.
