### PR TITLE
Mention that it's not possible to trigger a workflow from a PR when using BitBucket

### DIFF
--- a/docs/docs/using-semaphore/workflows.md
+++ b/docs/docs/using-semaphore/workflows.md
@@ -61,7 +61,7 @@ The following events or actions trigger workflows by default:
 
 Additionally, you can configure workflows to be triggered by:
 
-- Pull requests
+- Pull requests (not available on BitBucket projects)
 - Pull request on forked repositories
 
 The reason for the trigger can be determined at runtime by examining the Semaphore environment variables in the job. See the [environment variable reference page](../reference/env-vars#semaphore) for more details.

--- a/docs/versioned_docs/version-CE/using-semaphore/workflows.md
+++ b/docs/versioned_docs/version-CE/using-semaphore/workflows.md
@@ -59,7 +59,7 @@ The following events or actions trigger workflows by default:
 
 Additionally, you can configure workflows to be triggered by:
 
-- Pull requests
+- Pull requests (not available on BitBucket projects)
 - Pull request on forked repositories
 
 The reason for the trigger can be determined at runtime by examining the Semaphore environment variables in the job. See the [environment variable reference page](../reference/env-vars#semaphore) for more details.


### PR DESCRIPTION
## What
Mention that it's not possible to trigger a workflow from a PR when using BitBucket

## Why
See https://github.com/semaphoreio/semaphore/issues/110

## Checklist: 
<!-- Ensure your PR meets all the contribution guidelines. --> 

Use a checklist to confirm:
- [x] The branch is up-to-date with the main branch.
- [x] Update follows the docs [style guide](../../docs/docs-contributing/STYLE_GUIDE.md).
- [x] Changes have been tested locally.
